### PR TITLE
change channel condition for kernal size

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "python.pythonPath": "/root/anaconda3/bin/python"
+    "python.pythonPath": "/Users/yaya/miniconda3/envs/deepmot/bin/python"
 }

--- a/models/eca_mobilenetv2.py
+++ b/models/eca_mobilenetv2.py
@@ -74,7 +74,7 @@ class ECA_MobileNetV2(nn.Module):
         for t, c, n, s in inverted_residual_setting:
             output_channel = int(c * width_mult)
             for i in range(n):
-                if c <= 96:
+                if c < 96:
                     ksize = 1
                 else:
                     ksize = 3


### PR DESCRIPTION
When I load the eca_mobilenetv2_k13.pth 2.tar, it told me that the defined model ECA_MobileNetV2 and the pertained model don't match correctly in feature 11,12,13 layers. And when I change "<=" into "=", it worked. 